### PR TITLE
Potential fix for code scanning alert no. 10: Missing cross-site request forgery token validation

### DIFF
--- a/src/App.Web/Controllers/ReportsController.cs
+++ b/src/App.Web/Controllers/ReportsController.cs
@@ -1018,6 +1018,7 @@ namespace App.Web.Controllers
 
         [HttpPost]
         [Route("load-identified-salary-accounts")]
+        [ValidateAntiForgeryToken]
         public ActionResult LoadIdentifiedSalaryAccounts(string q)
         {
             const string callerFormMethod = "HttpGet|LoadIdentifiedSalaryAccounts";


### PR DESCRIPTION
Potential fix for [https://github.com/tokzhee/SAMP/security/code-scanning/10](https://github.com/tokzhee/SAMP/security/code-scanning/10)

To fix the missing CSRF validation, add the `[ValidateAntiForgeryToken]` attribute to the `LoadIdentifiedSalaryAccounts` method. This ensures that any POST request to this action must include a valid anti-forgery token, which is typically rendered in forms using `@Html.AntiForgeryToken()` in Razor views. The change should be made directly above the method definition, alongside the existing `[HttpPost]` and `[Route]` attributes. No other code changes are required, and no new imports are needed since `System.Web.Mvc` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
