### PR TITLE
Potential fix for code scanning alert no. 2: Weak encryption

### DIFF
--- a/src/App.Core/Utilities/EncryptionUtility.cs
+++ b/src/App.Core/Utilities/EncryptionUtility.cs
@@ -11,13 +11,15 @@ namespace App.Core.Utilities
         {
             try
             {
-                TripleDESCryptoServiceProvider service = new TripleDESCryptoServiceProvider();
-                MD5CryptoServiceProvider md5 = new MD5CryptoServiceProvider();
-
-                byte[] key = md5.ComputeHash(Encoding.ASCII.GetBytes(password));
-                byte[] iv = md5.ComputeHash(Encoding.ASCII.GetBytes(password));
-
-                return Transform(input, service.CreateEncryptor(key, iv));
+                AesCryptoServiceProvider service = new AesCryptoServiceProvider();
+                // Use PBKDF2 for key and IV derivation
+                byte[] salt = Encoding.UTF8.GetBytes("App.Core.Utilities.EncryptionUtility.Salt"); // Fixed salt for compatibility
+                using (var keyDerivation = new Rfc2898DeriveBytes(password, salt, 10000))
+                {
+                    byte[] key = keyDerivation.GetBytes(service.KeySize / 8);
+                    byte[] iv = keyDerivation.GetBytes(service.BlockSize / 8);
+                    return Transform(input, service.CreateEncryptor(key, iv));
+                }
             }
             catch (Exception)
             {
@@ -28,13 +30,15 @@ namespace App.Core.Utilities
         {
             try
             {
-                TripleDESCryptoServiceProvider service = new TripleDESCryptoServiceProvider();
-                MD5CryptoServiceProvider md5 = new MD5CryptoServiceProvider();
-
-                byte[] key = md5.ComputeHash(Encoding.ASCII.GetBytes(password));
-                byte[] iv = md5.ComputeHash(Encoding.ASCII.GetBytes(password));
-
-                return Transform(input, service.CreateDecryptor(key, iv));
+                AesCryptoServiceProvider service = new AesCryptoServiceProvider();
+                // Use PBKDF2 for key and IV derivation
+                byte[] salt = Encoding.UTF8.GetBytes("App.Core.Utilities.EncryptionUtility.Salt"); // Fixed salt for compatibility
+                using (var keyDerivation = new Rfc2898DeriveBytes(password, salt, 10000))
+                {
+                    byte[] key = keyDerivation.GetBytes(service.KeySize / 8);
+                    byte[] iv = keyDerivation.GetBytes(service.BlockSize / 8);
+                    return Transform(input, service.CreateDecryptor(key, iv));
+                }
             }
             catch (Exception)
             {


### PR DESCRIPTION
Potential fix for [https://github.com/tokzhee/SAMP/security/code-scanning/2](https://github.com/tokzhee/SAMP/security/code-scanning/2)

To fix the problem, replace the use of `TripleDESCryptoServiceProvider` with `AesCryptoServiceProvider` (or `AesManaged`), and replace the use of `MD5CryptoServiceProvider` for key and IV derivation with a secure key derivation function such as PBKDF2 (`Rfc2898DeriveBytes`). This will ensure that the encryption uses a strong algorithm (AES) and that the key and IV are derived securely from the password. The changes should be made in the `Encrypt` and `Decrypt` methods, specifically lines 14, 15, 17, 18, 31, 32, 34, and 35. You will need to import `System.Security.Cryptography` (already present) and use `Rfc2898DeriveBytes` to derive the key and IV from the password and a random salt. For simplicity and compatibility with the current API, you can use a fixed salt (but ideally, a random salt should be used and stored alongside the ciphertext).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
