### PR TITLE
Potential fix for code scanning alert no. 310: DOM text reinterpreted as HTML

### DIFF
--- a/src/App.Web/Assets/reports/tableExport/tableExport.js
+++ b/src/App.Web/Assets/reports/tableExport/tableExport.js
@@ -13,6 +13,19 @@
 'use strict';
 
 (function ($) {
+
+  // Escapes HTML special characters in a string
+  function escapeHtml(text) {
+    var map = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    };
+    return text.replace(/[&<>"']/g, function(m) { return map[m]; });
+  }
+
   $.fn.tableExport = function (options) {
     var defaults = {
       csvEnclosure:        '"',
@@ -660,7 +673,11 @@
         var $table = $(this);
 
         if (docName === '') {
-          docName = defaults.mso.worksheetName || $table.find('caption').text() || 'Table';
+          var captionText = $table.find('caption').text();
+          if (captionText) {
+            captionText = escapeHtml(captionText);
+          }
+          docName = defaults.mso.worksheetName || captionText || 'Table';
           docName = $.trim(docName.replace(/[\\\/[\]*:?'"]/g, '').substring(0, 31));
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/tokzhee/SAMP/security/code-scanning/310](https://github.com/tokzhee/SAMP/security/code-scanning/310)

To fix the vulnerability, we must ensure that any text extracted from the DOM (specifically, the table caption) is properly escaped before being written as HTML. The best way to do this is to encode special HTML characters (`<`, `>`, `&`, `"`, `'`) in the caption text before it is used in the document that is written to the iframe. This can be achieved by introducing a helper function (e.g., `escapeHtml`) that replaces these characters with their corresponding HTML entities. The escaping should be applied immediately after extracting the caption text, before it is used to build the document string (`docFile`). Specifically, in the block where `docName` is set (line 663), we should escape the value if it comes from the caption.

**Required changes:**
- Add an `escapeHtml` function to the file.
- Apply `escapeHtml` to the result of `$table.find('caption').text()` when assigning to `docName` (line 663).
- Ensure that only the caption-derived value is escaped, not the worksheet name from options.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
