### PR TITLE
Potential fix for code scanning alert no. 11: URL redirection from remote source

### DIFF
--- a/src/App.Web/Controllers/AccountController.cs
+++ b/src/App.Web/Controllers/AccountController.cs
@@ -167,7 +167,10 @@ namespace App.Web.Controllers
 
                         if (!string.IsNullOrEmpty(returnUrl) && HttpUtility.UrlDecode(returnUrl) != $"{ConfigurationUtility.GetAppSettingValue("ApplicationDeployedFolderPath")}/account/logout")
                         {
-                            return Redirect(returnUrl);
+                            if (Url.IsLocalUrl(returnUrl))
+                            {
+                                return Redirect(returnUrl);
+                            }
                         }
 
                         return RedirectToAction("dashboard", "home");


### PR DESCRIPTION
Potential fix for [https://github.com/tokzhee/SAMP/security/code-scanning/11](https://github.com/tokzhee/SAMP/security/code-scanning/11)

To fix the open redirect vulnerability, we must ensure that the `returnUrl` parameter is validated before it is used in a redirect. The best way is to only allow redirects to relative URLs (i.e., URLs that do not specify a host and are local to the application), or to a whitelist of known safe URLs. In this context, the simplest and safest fix is to check that `returnUrl` is a relative URL (not absolute, not starting with `http://` or `https://`, and not containing a host). If it is not, we should redirect to a default safe location (e.g., the dashboard). This change should be made in the `Login` POST action, specifically in the block where the redirect occurs (lines 168-173).

To implement this, we need to:
- Add a check to ensure `returnUrl` is a local URL (using `Url.IsLocalUrl(returnUrl)`).
- Only redirect to `returnUrl` if it passes this check; otherwise, redirect to a safe default (e.g., dashboard).
- No new imports are needed, as `Url.IsLocalUrl` is available in ASP.NET MVC.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
